### PR TITLE
Fixed 5 Warnings in src/common/EventContext.ts

### DIFF
--- a/src/common/ExecutionContext.ts
+++ b/src/common/ExecutionContext.ts
@@ -126,8 +126,8 @@ export class ExecutionContext {
    * await twoHandle.dispose();
    * console.log(result); // prints '3'.
    * ```
-   * @param pageFunction a function to be evaluated in the `executionContext`
-   * @param args argument to pass to the page function
+   * @param pageFunction - a function to be evaluated in the `executionContext`
+   * @param args - argument to pass to the page function
    *
    * @returns A promise that resolves to the return value of the given function.
    */
@@ -178,8 +178,8 @@ export class ExecutionContext {
    * await resultHandle.dispose();
    * ```
    *
-   * @param pageFunction a function to be evaluated in the `executionContext`
-   * @param args argument to pass to the page function
+   * @param pageFunction - a function to be evaluated in the `executionContext`
+   * @param args - argument to pass to the page function
    *
    * @returns A promise that resolves to the return value of the given function
    * as an in-page object (a {@link JSHandle}).
@@ -344,7 +344,7 @@ export class ExecutionContext {
    * await mapPrototype.dispose();
    * ```
    *
-   * @param prototypeHandle a handle to the object prototype
+   * @param prototypeHandle - a handle to the object prototype
    *
    * @returns A handle to an array of objects with the given prototype.
    */


### PR DESCRIPTION
when we run the command "npm run generate-docs", we were getting a number of warnings.
5 of which I have solved by introducing minor fixes!!!